### PR TITLE
fix(cuda): guard device-only builtins with __CUDA_ARCH__, not __CUDACC__

### DIFF
--- a/src/bbhx/cutils/PhenomHMWaveform.cu
+++ b/src/bbhx/cutils/PhenomHMWaveform.cu
@@ -2595,7 +2595,7 @@ void calculate_modes_phenomd(int binNum, double *amps, double *phases, double *t
     double eps = 1e-9;
 
     int start, increment;
-#ifdef __CUDACC__
+#if defined(__CUDA_ARCH__)
     start = threadIdx.x;
     increment = blockDim.x;
 #else
@@ -2637,7 +2637,7 @@ void calculate_modes(int binNum, int mode_i, double *amps, double *phases, doubl
     double eps = 1e-9;
 
     int start, increment;
-#ifdef __CUDACC__
+#if defined(__CUDA_ARCH__)
     start = threadIdx.x;
     increment = blockDim.x;
 #else


### PR DESCRIPTION
The BBHx CUDA extension builds and links, then fails at import:

```
ImportError: .../bbhx_backend_cuda12x/cbbhx...so:
undefined symbol: __device_builtin_variable_blockDim
```

`calculate_modes_phenomd` (~L2593) and `calculate_modes` (~L2635) in `src/bbhx/cutils/PhenomHMWaveform.cu` are `CUDA_CALLABLE_MEMBER` (`__host__ __device__`) and guard their loop setup with `#ifdef __CUDACC__` before reading `threadIdx.x` / `blockDim.x`.

`__CUDACC__` only means *nvcc is compiling this translation unit* — it does not separate the host pass from the device pass, so the host variants also reference device built-ins. `__CUDA_ARCH__` is defined only during the device pass, which is the distinction intended here.

Verifiable without a GPU:
```
nm -D .../cbbhx*.so | grep __device_builtin_variable
```
A clean rebuild reproduces.

Suggested follow-up (not in this PR): link with `-Wl,--no-undefined` so this class of bug fails at build time rather than at import.

Context: one of three patches needed to get the MBH GPU global fit running on ACCRE — https://github.com/lisa-analysis-tools/lisa-analysis-tools/issues/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)